### PR TITLE
Placeholders should be wraped with braces

### DIFF
--- a/src/MetaBasedGenerator.php
+++ b/src/MetaBasedGenerator.php
@@ -129,7 +129,7 @@ class MetaBasedGenerator extends AbstractGenerator
                 return;
             }
 
-            // remove brackets
+            // remove braces
             $expressions = preg_replace('/[{}]/', '', $m['expressions']);
             // replace placeholders to real column attributes
             $expressions = array_intersect_key(array_flip($expressions), $column);

--- a/src/MetaBasedGenerator.php
+++ b/src/MetaBasedGenerator.php
@@ -119,17 +119,14 @@ class MetaBasedGenerator extends AbstractGenerator
      */
     final private function getExpressionsForPlaceholders(array $column, array $meta)
     {
-        $result = [];
-
         if (in_array($column['name'], $this->placeholdersExclude)) {
             return [];
         }
 
-        foreach ($meta as $m) {
+        return array_filter(array_map(function ($m) use ($column) {
             // pattern expressions can not have placeholders
-            //dd($expressions, array_key_exists('pattern', $expressions));
             if (array_key_exists('pattern', $m) || ! array_key_exists('actions', $m)) {
-                continue;
+                return;
             }
 
             // replace placeholders to real column attributes
@@ -140,12 +137,8 @@ class MetaBasedGenerator extends AbstractGenerator
 
             $replaced = array_combine($expressions, $column);
             // restore regular actions (which are not placeholders)
-            $replaced = array_merge($m['actions'], $replaced);
-
-            array_push($result, $replaced);
-        }
-
-        return $result;
+            return array_merge($m['actions'], $replaced);
+        }, $meta));
     }
 
     /**

--- a/src/MetaBasedGenerator.php
+++ b/src/MetaBasedGenerator.php
@@ -72,7 +72,7 @@ class MetaBasedGenerator extends AbstractGenerator
     final private function handleTable($migrationMethod)
     {
         foreach ($this->meta[$migrationMethod] as $m) {
-            if (! array_key_exists('actions', $m)) {
+            if (! array_key_exists('expressions', $m)) {
                 $this->generateByMeta($m);
             }
         }
@@ -105,7 +105,7 @@ class MetaBasedGenerator extends AbstractGenerator
                 array_key_exists('pattern', $m) &&
                 ! empty(array_intersect($column, $m['pattern']))
             ) {
-                return $m['actions'];
+                return $m['expressions'];
             }
         }
 
@@ -125,19 +125,19 @@ class MetaBasedGenerator extends AbstractGenerator
 
         return array_filter(array_map(function ($m) use ($column) {
             // pattern expressions can not have placeholders
-            if (array_key_exists('pattern', $m) || ! array_key_exists('actions', $m)) {
+            if (array_key_exists('pattern', $m) || ! array_key_exists('expressions', $m)) {
                 return;
             }
 
             // replace placeholders to real column attributes
-            $expressions = array_intersect_key(array_flip($m['actions']), $column);
+            $expressions = array_intersect_key(array_flip($m['expressions']), $column);
             // sort in order to combine
             asort($expressions);
             asort($column);
 
             $replaced = array_combine($expressions, $column);
-            // restore regular actions (which are not placeholders)
-            return array_merge($m['actions'], $replaced);
+            // restore regular expressions (which are not placeholders)
+            return array_merge($m['expressions'], $replaced);
         }, $meta));
     }
 

--- a/src/MetaBasedGenerator.php
+++ b/src/MetaBasedGenerator.php
@@ -129,8 +129,10 @@ class MetaBasedGenerator extends AbstractGenerator
                 return;
             }
 
+            // remove brackets
+            $expressions = preg_replace('/[{}]/', '', $m['expressions']);
             // replace placeholders to real column attributes
-            $expressions = array_intersect_key(array_flip($m['expressions']), $column);
+            $expressions = array_intersect_key(array_flip($expressions), $column);
             // sort in order to combine
             asort($expressions);
             asort($column);

--- a/src/MetaBasedGenerator.php
+++ b/src/MetaBasedGenerator.php
@@ -80,7 +80,10 @@ class MetaBasedGenerator extends AbstractGenerator
     final private function handleColumns($migrationMethod)
     {
         foreach ($this->schema as $column) {
-            $actions = $this->getActionsByColumnSchema($column, $migrationMethod);
+            $patternActions = $this->getActionsByColumnSchema($column, $this->meta[$migrationMethod]);
+            $placeholderActions = $this->getActionsFillingPlaceholders($column, $this->meta[$migrationMethod]);
+            $actions = array_merge($patternActions, $placeholderActions);
+
             if (! empty($actions)) {
                 $this->generateByMeta($actions);
             }
@@ -91,9 +94,9 @@ class MetaBasedGenerator extends AbstractGenerator
      * @param array $column
      * @return array
      */
-    final private function getActionsByColumnSchema(array $column, $migrationMethod = 'up')
+    final private function getActionsByColumnSchema(array $column, array $meta)
     {
-        foreach ($this->meta[$migrationMethod] as $m) {
+        foreach ($meta as $m) {
             if (
                 array_key_exists('pattern', $m) &&
                 ! empty(array_intersect($column, $m['pattern']))
@@ -103,6 +106,17 @@ class MetaBasedGenerator extends AbstractGenerator
         }
 
         return [];
+    }
+
+    final private function getActionsFillingPlaceholders(array $columns, array $meta)
+    {
+        $actionsWithPlaceholders = array_filter($meta, function ($actionPredicate) {
+            return in_array(preg_replace('/[{}]/', '', $actionPredicate), ['name', 'type']);
+        });
+
+        return array_map(function ($col) use ($actionsWithPlaceholders) {
+            //@todo fill actions with placeholders
+        }, $columns);
     }
 
     /**

--- a/src/meta.php
+++ b/src/meta.php
@@ -7,14 +7,14 @@ return [
         'up' => [
             [
                 'pattern' => ['name' => 'id'],
-                'actions' => [
+                'expressions' => [
                     'call' => 'increments',
                     'of' => '$table',
                     'withArgs' => 'id',
                 ]
             ],
             [
-                'actions' => [
+                'expressions' => [
                     'call' => 'type',
                     'of' => '$table'
                 ],
@@ -27,7 +27,7 @@ return [
     'add' => [
         'up' => [
             'pattern' => ['name' => '.+_id'],
-            'actions' => [
+            'expressions' => [
                 [
                     'call' => 'foreign',
                     'of' => '$table',

--- a/src/meta.php
+++ b/src/meta.php
@@ -15,7 +15,7 @@ return [
             ],
             [
                 'expressions' => [
-                    'call' => 'type',
+                    'call' => '{type}',
                     'of' => '$table'
                 ],
             ]

--- a/src/meta.php
+++ b/src/meta.php
@@ -15,7 +15,7 @@ return [
             ],
             [
                 'actions' => [
-                    'call' => '{type}',
+                    'call' => 'type',
                     'of' => '$table'
                 ],
             ]

--- a/src/meta.php
+++ b/src/meta.php
@@ -11,12 +11,40 @@ return [
                     'call' => 'increments',
                     'of' => '$table',
                     'withArgs' => 'id',
-                    'callChain' => 'unsigned',
                 ]
             ],
+            [
+                'actions' => [
+                    'call' => '{type}',
+                    'of' => '$table'
+                ],
+            ]
         ],
         'down' => [
             ['call' => 'dropTable', 'of' => '$table']
+        ]
+    ],
+    'add' => [
+        'up' => [
+            'pattern' => ['name' => '.+_id'],
+            'actions' => [
+                [
+                    'call' => 'foreign',
+                    'of' => '$table',
+                    'withArgs' => '{column}',
+                ],
+                [
+                    'callChain' => 'references',
+                    'withArgs' => 'id',
+                ],
+                [
+                    'callChain' => 'on',
+                    'withArgs' => '{parent table}',
+                ]
+            ]
         ],
+        'down' => [
+            //@todo fill [down] meta
+        ]
     ],
 ];

--- a/tests/MetaBasedGeneratorTest.php
+++ b/tests/MetaBasedGeneratorTest.php
@@ -10,13 +10,14 @@ class MetaBasedGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateUp()
     {
         $generator = new MetaBasedGenerator(
-            [['name' => 'id']],
+            [['name' => 'id'], ['name' => 'title', 'type' => 'string']],
             $this->provider()
         );
 
         $this->assertEquals(
             $generator->generateUp(),
-            '$table->increments(\'id\')->unsigned();'.PHP_EOL
+            '$table->increments(\'id\')->unsigned();'.PHP_EOL.
+            '$table->string(\'title\');'.PHP_EOL
         );
     }
 
@@ -46,6 +47,13 @@ class MetaBasedGeneratorTest extends \PHPUnit_Framework_TestCase
                         'callChain' => 'unsigned',
                     ]
                 ],
+                [
+                    'actions' => [
+                        'call' => 'type',
+                        'of' => '$table',
+                        'withArgs' => 'name'
+                    ],
+                ]
             ],
             'down' => [
                 ['call' => 'dropTable', 'of' => '$table']

--- a/tests/MetaBasedGeneratorTest.php
+++ b/tests/MetaBasedGeneratorTest.php
@@ -40,7 +40,7 @@ class MetaBasedGeneratorTest extends \PHPUnit_Framework_TestCase
             'up' => [
                 [
                     'pattern' => ['name' => 'id'],
-                    'actions' => [
+                    'expressions' => [
                         'call' => 'increments',
                         'of' => '$table',
                         'withArgs' => 'id',
@@ -48,7 +48,7 @@ class MetaBasedGeneratorTest extends \PHPUnit_Framework_TestCase
                     ]
                 ],
                 [
-                    'actions' => [
+                    'expressions' => [
                         'call' => 'type',
                         'of' => '$table',
                         'withArgs' => 'name'

--- a/tests/MetaBasedGeneratorTest.php
+++ b/tests/MetaBasedGeneratorTest.php
@@ -49,9 +49,9 @@ class MetaBasedGeneratorTest extends \PHPUnit_Framework_TestCase
                 ],
                 [
                     'expressions' => [
-                        'call' => 'type',
+                        'call' => '{type}',
                         'of' => '$table',
-                        'withArgs' => 'name'
+                        'withArgs' => '{name}'
                     ],
                 ]
             ],


### PR DESCRIPTION
Change foreach usage to array_map
Replace 'actions' key to more clear 'expressions'
Placeholders on metadata are now wraped by braces
Fix comment
